### PR TITLE
Move STAC root to l2-ard (from one level deeper) and support generic continents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### New
 
+- Level 2 supports any continent (not just europe). Multiple continents are still not supported
+
 ### Fixed
 
-- STAC catalog is generated in output root and not in "l2-ard/europe" subdirectory
+- STAC catalog is generated in output root ("l2-ard") and not in "l2-ard/europe" subdirectory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,10 @@
 # CHANGELOG
+
+
+## [Unreleased]
+
+### New
+
+### Fixed
+
+- STAC catalog is generated in output root and not in "l2-ard/europe" subdirectory

--- a/bin/force-level2-wrapper.sh
+++ b/bin/force-level2-wrapper.sh
@@ -246,7 +246,19 @@ gen-stac() {
   uv run --project /opt/force-python-tools --no-sync gen-stac "$@"
 }
 
-# TODO instead of hardcoded europe, generate stac for each continent
-mv outputs/l2-ard/CITEME* outputs/l2-ard/europe/
+# FIXME this generates a stac item for each continent, but a single catalog per item which will be overwritten by each iteration
+# Hence, only a single continent is supported. However, it solves the previous issue, that only
+# europe as a continent is supported.
+# TODO Furthermore, neither of the existing solutions has been tested with procjection other than GLANCE7, so it
+# must be checked whether other projections also generate subdirectories.
 
-gen-stac outputs/l2-ard/europe --output-path outputs/l2-ard/europe --item-id "$processing_name-level2" --type level2
+for dir in outputs/l2-ard/*/; do
+  continent_dir="${dir%/}"
+  continent_dir="${continent_dir##*/}"
+  echo "continent: $continent_dir"
+  cp outputs/l2-ard/CITEME* "outputs/l2-ard/$continent_dir/"
+  mkdir -p "outputs/l2-ard/$continent_dir/param"
+  cp param/l2ps.prm "outputs/l2-ard/$continent_dir/param/l2ps.prm"
+
+  gen-stac "outputs/l2-ard/$continent_dir" --output-path "$(realpath "outputs/l2-ard/")" --item-id "$processing_name-$continent_dir-level2" --type "level2" --parameter-path "outputs/l2-ard/$continent_dir/param/l2ps.prm"
+done

--- a/cwl/docker-requirement.yaml
+++ b/cwl/docker-requirement.yaml
@@ -1,1 +1,1 @@
-quay.io/bcdev/force-eoap:0.5.6
+quay.io/bcdev/force-eoap:0.5.7-dev1

--- a/cwl/docker-requirement.yaml
+++ b/cwl/docker-requirement.yaml
@@ -1,1 +1,1 @@
-quay.io/bcdev/force-eoap:0.5.7-dev1
+quay.io/bcdev/force-eoap:0.5.7-dev4

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "force-python-utils"
-version = "0.5.6"
+version = "0.5.7-dev0"
 requires-python = ">= 3.10"
 dependencies = [
-    "click>=8.3.3",
+    "click>=8.4.1",
     "geopandas>=1.1.3",
     "py-multihash>=3.0.0",
     "pystac[validation]>=1.14.3",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "force-python-utils"
-version = "0.5.7-dev0"
+version = "0.5.7-dev1"
 requires-python = ">= 3.10"
 dependencies = [
     "click>=8.4.1",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "force-python-utils"
-version = "0.5.7-dev1"
+version = "0.5.7-dev4"
 requires-python = ">= 3.10"
 dependencies = [
     "click>=8.4.1",

--- a/python/src/force_utils/cli.py
+++ b/python/src/force_utils/cli.py
@@ -73,6 +73,7 @@ def gen_stac(datacube_root, output_path, item_id, type, parameter_path, validate
     )
     catalog = stac_builder.generate_stac(item_id=item_id)
     catalog.normalize_hrefs(str(output_path))
+    catalog.make_all_asset_hrefs_relative()
     if validate:
         catalog.validate_all()
     logger.info(f"Saving STAC catalog to {output_path.resolve()}")

--- a/python/src/force_utils/contributor.py
+++ b/python/src/force_utils/contributor.py
@@ -485,23 +485,22 @@ class CommonMetadataStacContributor(AbstractStacContributor):
                 cls.process_parameter_file(parameter_path, store, item=item)
 
         # datacube-definition.prj
-        data_cube_definition_local_path = store.data_cube_definition_path.name
         data_cube_definition_asset = pystac.Asset(
-            href=data_cube_definition_local_path,
+            href=str(store.data_cube_definition_path),
             title="Data Cube Definition",
             media_type=pystac.MediaType.TEXT,
             roles=["metadata"],
             # TODO
             # decription = ...,
         )
-        data_cube_definition_asset.ext.file.local_path = data_cube_definition_local_path
+        data_cube_definition_asset.ext.file.local_path = store.data_cube_definition_path.name
         item.add_asset("datacube-definition.prj", data_cube_definition_asset)
 
         # citeme
         citeme_local_path = store.get_relative_path(store._citeme_path)
         if citeme_local_path is not None:
             citeme_asset = pystac.Asset(
-                href=str(citeme_local_path),
+                href=str(store._citeme_path),
                 title="CITEME",
                 media_type=pystac.MediaType.TEXT,
                 roles=["metadata"],
@@ -541,9 +540,8 @@ class CommonMetadataStacContributor(AbstractStacContributor):
                 item.properties[key][param_name] = param_value
 
         try:
-            parameter_path_relative = store.get_relative_path(parameter_path)
             parameter_asset = pystac.Asset(
-                href=str(parameter_path_relative),
+                href=str(parameter_path),
                 title="FORCE parameter file",
                 media_type=pystac.MediaType.TEXT,
                 roles=["metadata"],

--- a/python/src/force_utils/force_stac.py
+++ b/python/src/force_utils/force_stac.py
@@ -73,7 +73,7 @@ class ForceStacBuilder:
 
                 asset_key = self._get_asset_key(tile, asset_path_relative)
                 asset = pystac.Asset(
-                    href=str(asset_path_relative),
+                    href=str(asset_path),
                 )
                 item.add_asset(asset_key, asset)
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -441,7 +441,7 @@ wheels = [
 
 [[package]]
 name = "force-python-utils"
-version = "0.5.7.dev0"
+version = "0.5.7.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -441,7 +441,7 @@ wheels = [
 
 [[package]]
 name = "force-python-utils"
-version = "0.5.7.dev1"
+version = "0.5.7.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -384,14 +384,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ wheels = [
 
 [[package]]
 name = "force-python-utils"
-version = "0.5.6"
+version = "0.5.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -462,7 +462,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
-    { name = "click", specifier = ">=8.3.3" },
+    { name = "click", specifier = ">=8.4.1" },
     { name = "geopandas", specifier = ">=1.1.3" },
     { name = "py-multihash", specifier = ">=3.0.0" },
     { name = "pystac", extras = ["validation"], specifier = ">=1.14.3" },

--- a/test/test_force_level2_cltool.sh
+++ b/test/test_force_level2_cltool.sh
@@ -41,7 +41,7 @@ cwltool \
 
 
 # check that asset links can be found
-cd "$outdir/l2-ard/europe" # must check relative paths in the assets from outdir
+cd "$outdir/l2-ard" # must check relative paths in the assets from outdir
 pwd
 missing=0
 find . -name 'cube-*.json' -print0 |


### PR DESCRIPTION
This PR changes the layout of the STAC catalog produced by level 2

- Catalog is produced in l2-ard (not one level down as before)
- Items will be generated for each subdirectory of l2-ard, not just the hardcoded "europe" one
- Assets are assigned relative paths with pystac functionality, not by hand