### PR TITLE
Hn limit connections

### DIFF
--- a/cwl/docker-requirement.yaml
+++ b/cwl/docker-requirement.yaml
@@ -1,1 +1,1 @@
-quay.io/bcdev/force-eoap:0.6.0
+quay.io/bcdev/force-eoap:0.6.1-dev0

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ authors = [
 channels = ["conda-forge"]
 name = "apex-force-openeo"
 platforms = ["linux-64"]
-version = "0.6.0"
+version = "0.6.1-dev0"
 
 [tasks]
 test-openeo = { cmd = [ "pytest", "test/openeo" ], default-environment = "test" }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "force-python-utils"
-version = "0.6.0"
+version = "0.6.1-dev0"
 requires-python = ">= 3.10"
 dependencies = [
     "click>=8.4.1",

--- a/python/src/stac_staging/download.py
+++ b/python/src/stac_staging/download.py
@@ -18,6 +18,7 @@ from stac_staging.util import unwrap_single_dir_level
 
 LOGGER = logging.getLogger(__name__)
 S5CMD = "s5cmd"
+S5CMD_NUM_WORKERS = 10
 
 S3_ENDPOINT_URL = "S3_ENDPOINT_URL"
 AWS_ENDPOINT_URL_S3 = "AWS_ENDPOINT_URL_S3"
@@ -199,4 +200,4 @@ def _construct_enclosure_link_from_item(item: pystac.Item) -> str:
 
 
 def _run_s5cmd(cmd_file: str):
-    return subprocess.run([S5CMD, "run", cmd_file])
+    return subprocess.run([S5CMD, "--numworkers", str(S5CMD_NUM_WORKERS), "run", cmd_file])

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -446,7 +446,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "force-python-utils"
-version = "0.6.0"
+version = "0.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Addresses https://github.com/bcdev/apex-force-openeo/issues/53. s5cmd uses 256 workers by default creating a very large number of connections. Limiting the number of workers is intended to reduce the demand on the system.